### PR TITLE
fix: Remove boost library from vcpkg.json, use crow instead

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "dependencies": [
     "concurrentqueue",
-    "boost-asio",
-    "boost-beast",
+    "crow",
     "nlohmann-json"
   ]
 }


### PR DESCRIPTION
Crow will be used as an API handler since its easier to use than raw Asio